### PR TITLE
Deduplicate mentioned users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+.dccache

--- a/lib/avokudos.js
+++ b/lib/avokudos.js
@@ -37,7 +37,7 @@ class Avokudos {
   }
 
   getMentionedUsers = (text) => {
-    return text.match(/<@\w+>/g)
+    return [...new Set(text.match(/<@\w+>/g))]
   }
 
   hearMessage = async (res) => {

--- a/test/avokudos.test.js
+++ b/test/avokudos.test.js
@@ -43,7 +43,7 @@ describe('avokudos', () => {
     expect(text).toBe('test message')
   })
 
-  it('gets mentioned users from text', () => {
+  it('gets unique mentioned users from text', () => {
     let text = 'hi <@test>! how are you?'
     let users = avokudos.getMentionedUsers(text)
     expect(users).toStrictEqual(['<@test>'])
@@ -51,6 +51,10 @@ describe('avokudos', () => {
     text = "hey <@test2> this is <@test>. I'm good, how are you?"
     users = avokudos.getMentionedUsers(text)
     expect(users).toStrictEqual(['<@test2>', '<@test>'])
+
+    text = 'hi <@test>! how are you? Mentioning you twice for double the avocados! <@test>'
+    users = avokudos.getMentionedUsers(text)
+    expect(users).toStrictEqual(['<@test>'])
   })
 
   it('gives users mentioned in a message with an avocado and gives those users an avocado', async () => {


### PR DESCRIPTION
Closes #2 which outlines that when a user is mentioned `N` times in a message, they are given `N` avocados instead of 1. This PR makes it so that they only get 1 avocado instead of `N` by de-duplicating the list of mentioned users in a message