### PR TITLE
Ignore bot users

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Snyk: [![Known Vulnerabilities](https://snyk.io/test/github/jrc356/avokudos/badg
    2. `chat:write`: for the bot to write messages
    3. `reactions:read`: so that the bot can react to reaction events
    4. `groups:history`: so that the bot can read and react to messages sent in private channels
+   5. `users:read`: so that the bot can determine if a user is a bot or not
 4. Install app in workspace
 5. Copy the `Bot User Oauth Toekn`
 6. Enable `Socket Mode` in `Settings > Socket Mode`

--- a/lib/avokudos.js
+++ b/lib/avokudos.js
@@ -45,19 +45,53 @@ class Avokudos {
     return [...new Set(text.match(/<@\w+>/g))]
   }
 
+  getUserInfo = async (client, userID) => {
+    return await client.users.info({
+      user: IDFromMention(userID)
+    })
+  }
+
+  userIsBot = async (client, userID) => {
+    const userInfo = await this.getUserInfo(client, userID)
+    return userInfo.user.is_bot
+  }
+
+  userIsEventUser = (user, eventUser) => {
+    return IDFromMention(user) === IDFromMention(eventUser)
+  }
+
+  filterUsers = async (client, eventUser, users) => {
+    const filteredUsers = []
+    for (const user of users) {
+      const userIsReactor = this.userIsEventUser(user, eventUser)
+      const userIsBot = await this.userIsBot(client, user)
+      if (!userIsReactor && !userIsBot) {
+        filteredUsers.push(user)
+      }
+    }
+    return filteredUsers
+  }
+
   hearMessage = async (res) => {
     console.log('Heard message containing :avocado:')
     const { message, client } = res
 
-    const mentionedUsers = this.getMentionedUsers(message.text)
+    const mentionedUsers = await this.filterUsers(
+      client,
+      message.user,
+      this.getMentionedUsers(message.text)
+    )
+
+    if (mentionedUsers.length < 1) {
+      return
+    }
+
     console.log(`${message.user} gave ${mentionedUsers} avocados via message in channel ${message.channel}`)
 
     const link = await this.getMessageLink(client, message.channel, message.ts)
     for (const user of mentionedUsers) {
-      if (IDFromMention(user) !== IDFromMention(message.user)) {
-        await this.keeper.giveUserKudos(user)
-        await this.sendUserKudosNotification(client, user, message.user, link)
-      }
+      await this.keeper.giveUserKudos(user)
+      await this.sendUserKudosNotification(client, user, message.user, link)
     }
   }
 
@@ -73,26 +107,26 @@ class Avokudos {
       event.item.ts
     )
     const link = await this.getMessageLink(client, event.item.channel, event.item.ts)
-    const mentionedUsers = this.getMentionedUsers(message)
+    const mentionedUsers = await this.filterUsers(
+      client,
+      event.user,
+      this.getMentionedUsers(message)
+    )
     if (mentionedUsers.length > 0) {
       console.log(`${event.user} gave an avocado to a message mentioning ${mentionedUsers} via reaction in channel ${event.item.channel}`)
       for (const user of mentionedUsers) {
-        if (IDFromMention(user) !== IDFromMention(event.user)) {
-          await this.keeper.giveUserKudos(user)
-          await this.sendUserKudosNotification(client, user, event.user, link)
-        }
+        await this.keeper.giveUserKudos(user)
+        await this.sendUserKudosNotification(client, user, event.user, link)
       }
-    } else {
+    } else if (!this.userIsEventUser(event.item_user, event.user)) {
       console.log(`${event.user} gave an avocado to ${event.item_user} via reaction in channel ${event.item.channel}`)
-      if (IDFromMention(event.item_user) !== IDFromMention(event.user)) {
-        await this.keeper.giveUserKudos(event.item_user)
-        await this.sendUserKudosNotification(
-          client,
-          event.item_user,
-          event.user,
-          link
-        )
-      }
+      await this.keeper.giveUserKudos(event.item_user)
+      await this.sendUserKudosNotification(
+        client,
+        event.item_user,
+        event.user,
+        link
+      )
     }
   }
 
@@ -107,19 +141,19 @@ class Avokudos {
       event.item.channel,
       event.item.ts
     )
-    const mentionedUsers = this.getMentionedUsers(message)
+    const mentionedUsers = await this.filterUsers(
+      client,
+      event.user,
+      this.getMentionedUsers(message)
+    )
     if (mentionedUsers.length > 0) {
       console.log(`${event.user} removed an avocado from a message mentioning ${mentionedUsers} in channel ${event.item.channel}`)
       for (const user of mentionedUsers) {
-        if (IDFromMention(user) !== IDFromMention(event.user)) {
-          await this.keeper.removeUserKudos(user)
-        }
+        await this.keeper.removeUserKudos(user)
       }
-    } else {
+    } else if (!this.userIsEventUser(event.item_user, event.user)) {
       console.log(`${event.user} removed an avocado from ${event.item_user} message in channel ${event.item.channel}`)
-      if (IDFromMention(event.item_user) !== IDFromMention(event.user)) {
-        await this.keeper.removeUserKudos(event.item_user)
-      }
+      await this.keeper.removeUserKudos(event.item_user)
     }
   }
 


### PR DESCRIPTION
This PR makes it so that the app ignores avocados given to bot users by updating the way that users are filtered